### PR TITLE
Add minutes formatting to elapsed time pipe

### DIFF
--- a/client/src/app/pipes/elapsed-time.pipe.ts
+++ b/client/src/app/pipes/elapsed-time.pipe.ts
@@ -7,13 +7,13 @@ export class ElapsedTimePipe implements PipeTransform {
         if (!startAndEndDateString.start || !startAndEndDateString.end) {
             return '...';
         }
-        const startToEndDiff = moment(startAndEndDateString.end).diff(startAndEndDateString.start);
-        const seconds = moment.duration(startToEndDiff).asSeconds();
+        const startToEndDuration = moment.duration(moment(startAndEndDateString.end).diff(startAndEndDateString.start));
+        const diffInSeconds = startToEndDuration.asSeconds();
+        const seconds = startToEndDuration.seconds();
+        const minutes = startToEndDuration.minutes();
 
-        if (seconds < 60) {
-          return `${seconds.toFixed(2)}s`;
-        }
-
-        return moment(startToEndDiff).format('m[m] s[s]');
+        return diffInSeconds > 60
+          ? `${minutes}m ${seconds}s`
+          : `${seconds.toFixed(2)}s`;
     }
 }

--- a/client/src/app/pipes/elapsed-time.pipe.ts
+++ b/client/src/app/pipes/elapsed-time.pipe.ts
@@ -7,8 +7,13 @@ export class ElapsedTimePipe implements PipeTransform {
         if (!startAndEndDateString.start || !startAndEndDateString.end) {
             return '...';
         }
-        const asSeconds = moment.duration(moment(startAndEndDateString.end).diff(startAndEndDateString.start)).asSeconds();
+        const startToEndDiff = moment(startAndEndDateString.end).diff(startAndEndDateString.start);
+        const seconds = moment.duration(startToEndDiff).asSeconds();
 
-        return `${asSeconds.toFixed(2)}s`;
+        if (seconds < 60) {
+          return `${seconds.toFixed(2)}s`;
+        }
+
+        return moment(startToEndDiff).format('m[m] s[s]');
     }
 }


### PR DESCRIPTION
~Not tested locally, need to setup dev environment.~

The changes look like this in-app:

<img width="143" alt="Screenshot 2019-03-12 at 14 59 18" src="https://user-images.githubusercontent.com/5813378/54206052-e0b31180-44d7-11e9-8501-8988911ba32d.png">
